### PR TITLE
Check casing script

### DIFF
--- a/.travis-check.sh
+++ b/.travis-check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if grep --color=always -rE '(Symbiflow|simbi[fF]low)' source/; then
+    echo "Found incorrect casing of SymbiFlow"
+    exit 1
+else
+    exit 0
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
   - ./.travis-deploy-clone.sh
 
 script:
+  - ./.travis-check.sh
   - gulp build
 
 after_success:
   - ./.travis-deploy-push.sh
-

--- a/source/index.html
+++ b/source/index.html
@@ -61,7 +61,7 @@
         </ul>
       </p>
       <p class="about__paragraph">
-        Symbiflow is meant to enable new innovation, as well as optimisation and automation of FPGA development workflows, to help make FPGA more accessible to a broad community of software developers who might otherwise be discouraged by the closed and vendor-specific workflows of today.
+        SymbiFlow is meant to enable new innovation, as well as optimisation and automation of FPGA development workflows, to help make FPGA more accessible to a broad community of software developers who might otherwise be discouraged by the closed and vendor-specific workflows of today.
       </p>
     </div>
   </section>


### PR DESCRIPTION
Fixes #8 

My original approach was to grep case insensitive for symbiflow, then remove SymbiFlow. This does not work because the all-lowercase "symbiflow" appears in a lot of URL's.