### PR TITLE
Fix spelling of Migen

### DIFF
--- a/source/index.hbs
+++ b/source/index.hbs
@@ -87,7 +87,7 @@
         For both ASIC- and FPGA-oriented EDA tooling, there are three major areas that the workflow needs to cover: hardware description, frontend and backend.
       </p>
       <p class="diagrams__paragraph">
-        Hardware description languages are generally open, with both established HDLs such as Verilog and VHDL and emerging software-inspired paradigms like Chisel, SpinalHDL or MiGen. The major problem lies however in the front- and backend, where previously there was no established standard, vendor-neutral tooling that would cover all the necessary components for an end-to-end flow.
+        Hardware description languages are generally open, with both established HDLs such as Verilog and VHDL and emerging software-inspired paradigms like Chisel, SpinalHDL or Migen. The major problem lies however in the front- and backend, where previously there was no established standard, vendor-neutral tooling that would cover all the necessary components for an end-to-end flow.
       </p>
       <p class="diagrams__paragraph">
         This pertains both to ASIC and FPGA workflows, although SymbiFlow focuses on the latter (some parts of SymbiFlow will also be useful in the former).


### PR DESCRIPTION
From [README](https://github.com/m-labs/migen):

> Note that Migen is **not** spelled MiGen.