### PR TITLE
Move the "Help wanted" section to the top of "Contribute now" webpage

### DIFF
--- a/source/assets/scss/developers.scss
+++ b/source/assets/scss/developers.scss
@@ -9,7 +9,7 @@
 // ***********************
 
 .tools {
-  margin: 320px auto 0;
+  margin: 80px auto 200px;
   padding: 120px 0 60px;
   @include tilted-bg(320px);
 
@@ -62,6 +62,7 @@
 }
 
 .help {
+  margin-top: 160px;
   padding: 90px 0 100px 0;
 }
 

--- a/source/developers.hbs
+++ b/source/developers.hbs
@@ -39,9 +39,55 @@
     </div>
   </nav>
 
+  <section class="row help" id="help">
+    <h2 class="row__header help__header">
+      Help wanted!
+    </h2>
+    <div class="help__content">
+      <p>
+        Are you interested in helping this project move forward? There are
+        multiple areas and technologies we need help with - reach out to us,
+        we’re sure we will find something for you.
+      </p>
+      <ul class="help__list">
+        <li>Do you know <span class="tech">Python</span>? Almost all scripts are written in Python!</li>
+        <li>Do you know <span class="tech">C++</span>? VPR & nextpnr & libraries written in C++!</li>
+        <li>Do you know <span class="tech">TCL</span>? All the EDA tools use TCL!</li>
+        <li>Do you know <span class="tech">Verilog</span>? Simulation and models are written in Verilog!</li>
+        <li>Do you know <span class="tech">XML</span>? Most file formats are XML!</li>
+        <li>Do you know English? Documentation is written in English!</li>
+        <li>Do you know <span class="tech">Docker</span>? Help make it easier to set up!</li>
+        <li>Do you have time? We will find you a task!</li>
+      </ul>
+    </div>
+    <div class="downloads__links help__links">
+      <a class="downloads__anchor" href="https://webchat.freenode.net/?channels=symbiflow">
+        <div class="btn btn--inverted">
+          IRC
+        </div>
+      </a>
+      <a class="downloads__anchor" href="https://lists.librecores.org/listinfo">
+        <div class="btn btn--inverted">
+          Mailing list
+        </div>
+      </a>
+      <a class="downloads__anchor" href="https://symbiflow.slack.com">
+        <div class="btn btn--inverted">
+          Slack
+        </div>
+      </a>
+    </div>
+    <div class="help__register">
+      To register to SymbiFlow's Slack workspace, use the following
+      <a class="inline-link" href="https://join.slack.com/t/symbiflow/shared_invite/enQtNTkyMjcyNTkzOTY4LTU0MzhmYWNjOGMyMTkyNjA0MmEyMWM5OWY3ZDg5MWQ3ODlmOWQwZjk2YzBmMDBjMzkzMzNjYjkwYjAxZTMyNjQ">
+        Slack Invite
+      </a>.
+    </div>
+  </section>
+
   <section class="row tools" id="tools">
     <h2 class="row__header tools__header">
-      What is SymbiFlow
+      About SymbiFlow
     </h2>
     <div class="tools__content">
       <p class="tools__paragraph">
@@ -127,52 +173,6 @@
           <a class="subproject__more inline-link" href="https://github.com/SymbiFlow/icestorm">learn more</a>
         </div>
       </div>
-    </div>
-  </section>
-
- <section class="row help" id="help">
-    <h2 class="row__header help__header">
-      Help wanted!
-    </h2>
-    <div class="help__content">
-      <p>
-        Are you interested in helping this project move forward? There are
-        multiple areas and technologies we need help with - reach out to us,
-        we’re sure we will find something for you.
-      </p>
-      <ul class="help__list">
-        <li>Do you know <span class="tech">Python</span>? Almost all scripts are written in Python!</li>
-        <li>Do you know <span class="tech">C++</span>? VPR & nextpnr & libraries written in C++!</li>
-        <li>Do you know <span class="tech">TCL</span>? All the EDA tools use TCL!</li>
-        <li>Do you know <span class="tech">Verilog</span>? Simulation and models are written in Verilog!</li>
-        <li>Do you know <span class="tech">XML</span>? Most file formats are XML!</li>
-        <li>Do you know English? Documentation is written in English!</li>
-        <li>Do you know <span class="tech">Docker</span>? Help make it easier to set up!</li>
-        <li>Do you have time? We will find you a task!</li>
-      </ul>
-    </div>
-    <div class="downloads__links help__links">
-      <a class="downloads__anchor" href="https://webchat.freenode.net/?channels=symbiflow">
-        <div class="btn btn--inverted">
-          IRC
-        </div>
-      </a>
-      <a class="downloads__anchor" href="https://lists.librecores.org/listinfo">
-        <div class="btn btn--inverted">
-          Mailing list
-        </div>
-      </a>
-      <a class="downloads__anchor" href="https://symbiflow.slack.com">
-        <div class="btn btn--inverted">
-          Slack
-        </div>
-      </a>
-    </div>
-    <div class="help__register">
-      To register to SymbiFlow's Slack workspace, use the following
-      <a class="inline-link" href="https://join.slack.com/t/symbiflow/shared_invite/enQtNTkyMjcyNTkzOTY4LTU0MzhmYWNjOGMyMTkyNjA0MmEyMWM5OWY3ZDg5MWQ3ODlmOWQwZjk2YzBmMDBjMzkzMzNjYjkwYjAxZTMyNjQ">
-        Slack Invite
-      </a>.
     </div>
   </section>
 


### PR DESCRIPTION
This commit moves the "Help wanted" section to the top of the "Contribute now" webpage.
It also changes the "What is Symbiflow" section title to "About SymbiFlow".

[[PREVIEV]](https://storage.googleapis.com/symbiflow-scratch/rw1nkler/symbiflow-website/b0d1ad3/developers.html)

Resolves #44