### PR TITLE
Add communication channels to main webpage

### DIFF
--- a/source/assets/scss/main.scss
+++ b/source/assets/scss/main.scss
@@ -1244,3 +1244,38 @@ a {
     background-color: $text-primary;
   }
 }
+
+// ***********************
+// COMMUNITY
+// ***********************
+
+.comm {
+  padding: 80px 0 120px 0;
+}
+
+.comm__header {
+  margin-bottom: 60px;
+}
+
+.comm__register {
+  text-align: center;
+  margin: 30px auto;
+}
+
+.comm__links {
+  max-width: 700px;
+  flex-wrap: wrap;
+
+  @media screen and (max-width: 700px) {
+    flex-direction: column;
+    align-items: center;
+
+    .btn {
+      width: 210px;
+    }
+
+    .downloads__anchor:not(:first-child) {
+      margin-top: 40px;
+    }
+  }
+}

--- a/source/index.hbs
+++ b/source/index.hbs
@@ -133,6 +133,35 @@
     </div>
  </section>
 
+  <section class="row comm" id="channels">
+    <h2 class="row__header comm__header">
+      Community Channels
+    </h2>
+    <div class="downloads__links comm__links">
+      <a class="downloads__anchor" href="https://webchat.freenode.net/?channels=symbiflow">
+        <div class="btn btn--inverted">
+          IRC
+        </div>
+      </a>
+      <a class="downloads__anchor" href="https://lists.librecores.org/listinfo">
+        <div class="btn btn--inverted">
+          Mailing list
+        </div>
+      </a>
+      <a class="downloads__anchor" href="https://symbiflow.slack.com">
+        <div class="btn btn--inverted">
+          Slack
+        </div>
+      </a>
+    </div>
+    <div class="comm__register">
+      To register to SymbiFlow's Slack workspace, use the following
+      <a class="inline-link" href="https://join.slack.com/t/symbiflow/shared_invite/enQtNTkyMjcyNTkzOTY4LTU0MzhmYWNjOGMyMTkyNjA0MmEyMWM5OWY3ZDg5MWQ3ODlmOWQwZjk2YzBmMDBjMzkzMzNjYjkwYjAxZTMyNjQ">
+        Slack Invite
+      </a>.
+    </div>
+  </section>
+
   <section class="row about" id="about">
     <h2 class="row__header about__header">
       Why SymbiFlow?


### PR DESCRIPTION
This commit adds section with links to the IRC, mailing list and Slack to the main webpage

[[PREVIEV]](https://storage.googleapis.com/symbiflow-scratch/rw1nkler/symbiflow-website/comm_channels/index.html)
