### PR TITLE
Remove GSoC banner

### DIFF
--- a/source/assets/scss/main.scss
+++ b/source/assets/scss/main.scss
@@ -202,7 +202,8 @@ a {
   height: 104px;
   margin: 0 auto;
   position: fixed;
-  top: 60px;
+  //top: 60px; with GSoC banner
+  top: 0px;
   background-color: $bg-primary;
   z-index: 9998;
   display: flex;

--- a/source/developers.hbs
+++ b/source/developers.hbs
@@ -13,10 +13,12 @@
 
 <body>
 
+<!--
   <div class="gsoc-banner">
     <span class="gsoc-banner__caption">SymbiFlow is participating in </span>
     <a href="https://summerofcode.withgoogle.com/organizations/6224851964002304/"><img class="gsoc-banner__logo" src="assets/img/gsoc-logo.svg" alt="Google's Summer of Code website"></a>
   </div>
+-->
 
   <nav class="nav">
     <div class="nav__wrapper">

--- a/source/getting-started.hbs
+++ b/source/getting-started.hbs
@@ -13,10 +13,12 @@
 
 <body>
 
+<!--
   <div class="gsoc-banner">
     <span class="gsoc-banner__caption">SymbiFlow is participating in </span>
     <a href="https://summerofcode.withgoogle.com/organizations/6224851964002304/"><img class="gsoc-banner__logo" src="assets/img/gsoc-logo.svg" alt="Google's Summer of Code website"></a>
   </div>
+-->
 
   <nav class="nav">
     <div class="nav__wrapper">

--- a/source/index.hbs
+++ b/source/index.hbs
@@ -22,12 +22,14 @@
 
 <body>
 
+<!--
   <div class="gsoc-banner">
     <span class="gsoc-banner__caption">SymbiFlow is participating in </span>
     <a href="https://summerofcode.withgoogle.com/organizations/6224851964002304/">
       <img class="gsoc-banner__logo" src="assets/img/gsoc-logo.svg" alt="Google's Summer of Code website" />
     </a>
   </div>
+-->
 
   <nav class="nav">
     <div class="nav__wrapper">


### PR DESCRIPTION
This commit removes GSoC banner from the website.

[[Preview]](https://storage.googleapis.com/symbiflow-scratch/rw1nkler/symbiflow-website/rm_gsoc/index.html)

Resolves: #50 