### PR TITLE
Fix link that pointed to Twitter instead of GitHub

### DIFF
--- a/source/index.hbs
+++ b/source/index.hbs
@@ -127,7 +127,7 @@
           <div class="news__header">
             <div class="news__header_container">
               <img src="assets/img/news_github.svg" />
-              <a href="https://twitter.com/symbiflow">SymbiFlow GitHub</a>
+              <a href="https://github.com/SymbiFlow/">SymbiFlow GitHub</a>
             </div>
           </div>
           <div id="feed"></div>


### PR DESCRIPTION
The changed link corresponds to the "SymbiFlow GitHub"-text in the image. Previously it pointed to Twitter.

![image](https://user-images.githubusercontent.com/58232418/85762909-81046800-b714-11ea-9e38-ee2effdbed5e.png)
