### PR TITLE
Add QuickLogic qlf_k4n8 eFPGA to supported architectures

### DIFF
--- a/source/index.hbs
+++ b/source/index.hbs
@@ -487,13 +487,22 @@
 
       <div class="subproject__tile">
         <div class="subproject__details">
+          <h4>QuickLogic QLF K4N8</h4>
+          <p class="subproject__description">
+            A 24x24 eFPGA with <br /> 6144 flip-flops, 4608 LUT4s, <br /> adder and shift-register support
+          </p>
+          <a class="subproject__more inline-link" target="_blank"
+             href="https://www.quicklogic.com/products/efpga/efpga-ip-software/">learn more
+          </a>
+        </div>
+      </div>
+
+      <div class="subproject__tile">
+        <div class="subproject__details">
           <h4>Do you want to <br /> add more?</h4>
           <p class="subproject__description">Help us!</p>
           <a class="subproject__more inline-link" href="developers.html">learn more</a>
         </div>
-      </div>
-
-      <div class="subproject__tile invisible">
       </div>
 
     </div>


### PR DESCRIPTION
This PR adds the QuickLogic qlf_k4n8 eFPGA to the list of supported FPGA architectures.