### PR TITLE
Reorganize getting started section

### DIFF
--- a/source/getting-started.hbs
+++ b/source/getting-started.hbs
@@ -53,24 +53,25 @@
           you through the process of using the toolchain, explaining how to
           generate and load a bitstream into your FPGA.
         </p>
-      <h3> RESOURCES: </h3>
+      <h3> User guide and examples how to use the toolchain: </h3>
+      </div>
+      <div class="getting__buttons">
+        <a href="https://github.com/SymbiFlow/symbiflow-examples">
+          <div class="btn">SymbiFlow Examples</div>
+        </a>
+      </div>
+      <div class="getting__content">
+      <h3> Other resources (for toolchain developers): </h3>
       </div>
       <div class="getting__buttons">
         <a href="https://symbiflow.readthedocs.io/en/latest/toolchain-desc.html">
           <div class="btn">Toolchain Description</div>
         </a>
 
-        <a href="https://symbiflow.readthedocs.io/projects/arch-defs/en/latest/getting-started.html">
-          <div class="btn">SymbiFlow on Arty Board</div>
-        </a>
-
         <a href="https://symbiflow.readthedocs.io/en/latest/prjxray/docs/db_dev_process/readme.html#quickstart-guide">
           <div class="btn">X-Ray Quickstart</div>
         </a>
 
-        <a href="https://github.com/SymbiFlow/symbiflow-examples">
-          <div class="btn">SymbiFlow Examples</div>
-        </a>
       </div>
     </section>
 


### PR DESCRIPTION
* Split links into user and devs sections
* Move symbiflow-examples to the top
* Drop Symbilow on Arty link (this is now part of examples)

With this change, getting started will look like:

![image](https://user-images.githubusercontent.com/3785621/123138968-f43ed800-d455-11eb-809d-330b761af1ff.png)
