### PR TITLE
ci: remove redundant 'cd build'; use 'set -e' in scripts

### DIFF
--- a/.github/scripts/check.sh
+++ b/.github/scripts/check.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if grep --color=always -rE '(Symbiflow|simbi[fF]low)' source/; then
     echo "Found incorrect casing of SymbiFlow"
     exit 1

--- a/.github/scripts/deploy-clone.sh
+++ b/.github/scripts/deploy-clone.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 GITHUB_USER=$(echo $GITHUB_REPOSITORY | sed -e's-/.*--')
 if [ "$GITHUB_USER" == "SymbiFlow" ]; then
 	git clone https://${GH_TOKEN}@github.com/SymbiFlow/symbiflow.github.io --branch master build

--- a/.github/scripts/deploy-push.sh
+++ b/.github/scripts/deploy-push.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+set -e
+
 GITHUB_USER=$(echo $GITHUB_REPOSITORY | sed -e's-/.*--')
 GIT_DESCRIBE=$(git describe --tags)
 
 cd build
+
 touch .nojekyll
 cat > README.md <<EOF
 # [SymbiFlow Website](https://symbiflow.github.io)

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,13 +39,14 @@ jobs:
           name: website-build
           path: /tmp/website-build
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Deploy website
         if: github.event_name == 'push'
         run: |
           git config --global user.name SymbiFlow
           git config --global user.mail robot@mith.ro
           git config --global push.default simple
-          git fetch origin --tags
           .github/scripts/deploy-clone.sh
           cp -a /tmp/website-build/* build
           ./.github/scripts/deploy-push.sh

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,5 +48,4 @@ jobs:
           git fetch origin --tags
           .github/scripts/deploy-clone.sh
           cp -a /tmp/website-build/* build
-          cd build
-          ../.github/scripts/deploy-push.sh
+          ./.github/scripts/deploy-push.sh


### PR DESCRIPTION
This PR  brings a couple of minor enhancements to the CI scripts.