### PR TITLE
Add link to Architectures Visualizer

### DIFF
--- a/source/getting-started.hbs
+++ b/source/getting-started.hbs
@@ -72,6 +72,10 @@
           <div class="btn">X-Ray Quickstart</div>
         </a>
 
+        <a href="https://antmicro.github.io/symbiflow-database-visualizer/">
+          <div class="btn">SymbiFlow FPGA Architectures Visualizer</div>
+        </a>
+
       </div>
     </section>
 


### PR DESCRIPTION
This PR adds a link to Architectures Visualizer in the getting started section