### PR TITLE
getting-started: add references to interesting repos in the org

### DIFF
--- a/source/getting-started.hbs
+++ b/source/getting-started.hbs
@@ -61,9 +61,24 @@
         </a>
       </div>
       <div class="getting__content">
-      <h3> Other resources (for toolchain developers): </h3>
+      <h3> Other resources:</h3>
       </div>
       <div class="getting__buttons">
+
+        <a href="https://github.com/SymbiFlow/sphinxcontrib-hdl-diagrams">
+          <div class="btn">sphinxcontrib-hdl-diagrams</div>
+        </a>
+
+        <a href="https://github.com/SymbiFlow/symbiflow-bitstream-viewer">
+          <div class="btn">Bitstream Viewer</div>
+        </a>
+
+      </div>
+      <div class="getting__content">
+      <h3> For toolchain developers:</h3>
+      </div>
+      <div class="getting__buttons">
+
         <a href="https://symbiflow.readthedocs.io/en/latest/toolchain-desc.html">
           <div class="btn">Toolchain Description</div>
         </a>
@@ -74,6 +89,10 @@
 
         <a href="https://antmicro.github.io/symbiflow-database-visualizer/">
           <div class="btn">SymbiFlow FPGA Architectures Visualizer</div>
+        </a>
+
+        <a href="https://github.com/SymbiFlow/fasm">
+          <div class="btn">FPGA Assembly (FASM) Parser and Generator</div>
         </a>
 
       </div>

--- a/source/getting-started.hbs
+++ b/source/getting-started.hbs
@@ -73,6 +73,10 @@
           <div class="btn">Bitstream Viewer</div>
         </a>
 
+        <a href="https://github.com/SymbiFlow/yosys-symbiflow-plugins">
+          <div class="btn">Yosys SymbiFlow Plugins</div>
+        </a>
+
       </div>
       <div class="getting__content">
       <h3> For toolchain developers:</h3>
@@ -93,6 +97,10 @@
 
         <a href="https://github.com/SymbiFlow/fasm">
           <div class="btn">FPGA Assembly (FASM) Parser and Generator</div>
+        </a>
+
+        <a href="https://symbiflow.github.io/fpga-tool-perf">
+          <div class="btn">FPGA tool performance profiling</div>
         </a>
 
       </div>


### PR DESCRIPTION
This PR adds references to some interesting repos in the org, which might go unnoticed:

- sphinxcontrib-hdl-diagrams
- yosys-symbiflow-plugins
- symbiflow-bitstream-viewer
- fasm
- fpga-tool-perf